### PR TITLE
Rework fileinput

### DIFF
--- a/src/components/Carousel.ts
+++ b/src/components/Carousel.ts
@@ -26,6 +26,7 @@ slidesTab.schema = [
             FileInput('image')
                 .label('Slide image')
                 .previewWidth(200)
+                .allowReorder()
                 .multiple()
                 .required(),
             TextInput('url')

--- a/src/components/Carousel.ts
+++ b/src/components/Carousel.ts
@@ -25,6 +25,8 @@ slidesTab.schema = [
                 .translatable(),
             FileInput('image')
                 .label('Slide image')
+                .previewWidth(50)
+                .previewAspect('square')
                 .required(),
             TextInput('url')
                 .label('Link URL (optional)')

--- a/src/components/Carousel.ts
+++ b/src/components/Carousel.ts
@@ -25,8 +25,7 @@ slidesTab.schema = [
                 .translatable(),
             FileInput('image')
                 .label('Slide image')
-                .previewWidth(50)
-                .previewAspect('square')
+                .previewWidth(200)
                 .required(),
             TextInput('url')
                 .label('Link URL (optional)')

--- a/src/components/Carousel.ts
+++ b/src/components/Carousel.ts
@@ -26,6 +26,7 @@ slidesTab.schema = [
             FileInput('image')
                 .label('Slide image')
                 .previewWidth(200)
+                .multiple()
                 .required(),
             TextInput('url')
                 .label('Link URL (optional)')

--- a/src/lib/components/form-builder/fields.ts
+++ b/src/lib/components/form-builder/fields.ts
@@ -240,6 +240,11 @@ class FieldBuilder implements IFieldBuilder {
         return this;
     }
 
+    allowReorder(allow: boolean = true): this {
+        this.field.allowReorder = allow;
+        return this;
+    }
+
     previewWidth(width: number): this {
         this.field.preview = { ...this.field.preview, width };
         return this;

--- a/src/lib/components/form-builder/fields.ts
+++ b/src/lib/components/form-builder/fields.ts
@@ -240,6 +240,11 @@ class FieldBuilder implements IFieldBuilder {
         return this;
     }
 
+    preview(options: { width?: number; height?: number; class?: string; aspect?: 'square' | 'video' | 'wide' | 'portrait' | string }): this {
+        this.field.preview = { ...this.field.preview, ...options };
+        return this;
+    }
+
     toJSON(): FormField { return this.field; }
     get fieldType(): FieldType { return this.field.type; }
     get name(): string { return this.field.name; }

--- a/src/lib/components/form-builder/fields.ts
+++ b/src/lib/components/form-builder/fields.ts
@@ -240,8 +240,20 @@ class FieldBuilder implements IFieldBuilder {
         return this;
     }
 
-    preview(options: { width?: number; height?: number; class?: string; aspect?: 'square' | 'video' | 'wide' | 'portrait' | string }): this {
-        this.field.preview = { ...this.field.preview, ...options };
+    previewWidth(width: number): this {
+        this.field.preview = { ...this.field.preview, width };
+        return this;
+    }
+    previewHeight(height: number): this {
+        this.field.preview = { ...this.field.preview, height };
+        return this;
+    }
+    previewClass(className: string): this {
+        this.field.preview = { ...this.field.preview, class: className };
+        return this;
+    }
+    previewAspect(aspect: 'square' | 'video' | 'wide' | 'portrait' | string): this {
+        this.field.preview = { ...this.field.preview, aspect };
         return this;
     }
 

--- a/src/lib/components/form-builder/fields/file-input/FileInput.svelte
+++ b/src/lib/components/form-builder/fields/file-input/FileInput.svelte
@@ -8,6 +8,7 @@
     import VideoPreview from "./VideoPreview.svelte";
     import { getFileUrl } from "@/services/file.service";
     import { errorToast } from "@/services/toast.service";
+    import Button from "$lib/components/ui/button/button.svelte";
 
     export let field: FormField;
     export let value: any = null; // single File / UploadedFile or array
@@ -119,7 +120,7 @@
     <!-- Drop Area -->
     <div
         class={cn(
-            "border-input data-[dragging=true]:bg-accent/50 has-[input:focus]:border-ring has-[input:focus]:ring-ring/50 relative flex min-h-48 flex-col overflow-hidden rounded-xl border border-dashed p-4 transition-colors has-[input:focus]:ring-[3px]",
+            "border-input bg-background dark:bg-input/30 data-[dragging=true]:bg-accent has-[input:focus]:border-ring has-[input:focus]:ring-ring/50 relative flex min-h-48 flex-col overflow-hidden rounded-xl border border-dashed p-4 transition-colors has-[input:focus]:ring-[3px]",
             currentFiles.length === 0
                 ? "items-center justify-center text-center"
                 : "gap-3",
@@ -301,7 +302,7 @@
                 class="flex flex-col items-center justify-center px-4 py-3 text-center select-none"
             >
                 <div
-                    class="mb-2 flex h-11 w-11 items-center justify-center rounded-full border bg-background"
+                    class="mb-2 flex h-11 w-11 items-center justify-center rounded-full border bg-background dark:bg-input/30"
                     aria-hidden="true"
                 >
                     <UploadIcon class="h-4 w-4 opacity-60" />
@@ -320,15 +321,16 @@
                         Max {formatFileSize(field.maxFileSize)}
                     {/if}
                 </p>
-                <button
+                <Button
                     type="button"
-                    class="mt-4 inline-flex items-center gap-2 rounded-md border bg-background px-3 py-2 text-sm font-medium hover:bg-accent transition disabled:opacity-50"
+                    variant="outline"
+                    class="mt-4 inline-flex items-center gap-2"
                     disabled={field.disabled || isProcessing}
-                    on:click={() => fileInput?.click()}
+                    onclick={() => fileInput?.click()}
                 >
                     <UploadIcon class="-ms-1 h-4 w-4 opacity-60" />
                     Select {field.multiple ? "files" : "file"}
-                </button>
+                </Button>
             </div>
         {/if}
     </div>

--- a/src/lib/components/form-builder/fields/file-input/FileInput.svelte
+++ b/src/lib/components/form-builder/fields/file-input/FileInput.svelte
@@ -157,28 +157,39 @@
         {#if currentFiles.length > 0}
             <!-- Header + Add more -->
             <div class="flex items-center justify-between gap-2">
-                <h3 class="truncate text-sm font-medium">
-                    {field.label || "Files"} ({currentFiles.length})
-                </h3>
+                <!-- Accessibility region -->
+                <p
+                    aria-live="polite"
+                    role="status"
+                    class="text-muted-foreground text-center text-xs mt-1"
+                >
+                    {currentFiles.length === 0
+                        ? "No files selected"
+                        : `${currentFiles.length} file${currentFiles.length === 1 ? "" : "s"} selected`}
+                </p>
                 {#if field.multiple}
-                    <button
-                        type="button"
-                        class="inline-flex items-center gap-1 rounded-md border bg-background px-2.5 py-1.5 text-xs font-medium hover:bg-accent transition disabled:opacity-50"
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        class="inline-flex items-center gap-1"
                         disabled={field.disabled || isProcessing}
-                        on:click={() => fileInput?.click()}
+                        onclick={() => fileInput?.click()}
                     >
                         <UploadIcon class="-ms-0.5 h-3.5 w-3.5 opacity-60" />
                         Add more
-                    </button>
+                    </Button>
                 {/if}
             </div>
             <!-- Grid -->
             <div
                 class={cn(
-                    "grid gap-3 mt-2",
                     field.multiple
-                        ? "grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
-                        : "grid-cols-1",
+                        ? field.preview &&
+                          (field.preview.width || field.preview.height)
+                            ? // When explicit sizing is provided, flex-wrap avoids grid min-content issues causing overlap
+                              "flex flex-wrap gap-3 mt-2"
+                            : "grid gap-3 mt-2 grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
+                        : "grid gap-3 mt-2 grid-cols-1",
                 )}
             >
                 {#each currentFiles as f (f.id || f.name || f.fileName)}
@@ -213,7 +224,7 @@
                         )}
                         style={field.preview &&
                         (field.preview.width || field.preview.height)
-                            ? `${field.preview.width ? `width:${field.preview.width}px;` : ""}${field.preview.height ? `height:${field.preview.height}px;` : ""}`
+                            ? `${field.preview.width ? `width:${field.preview.width}px;flex:0 0 ${field.preview.width}px;` : ""}${field.preview.height ? `height:${field.preview.height}px;` : ""}`
                             : undefined}
                     >
                         {#if isImage(data.mimeType)}
@@ -335,15 +346,4 @@
             </div>
         {/if}
     </div>
-
-    <!-- Accessibility region -->
-    <p
-        aria-live="polite"
-        role="status"
-        class="text-muted-foreground text-center text-xs mt-1"
-    >
-        {currentFiles.length === 0
-            ? "No files selected"
-            : `${currentFiles.length} file${currentFiles.length === 1 ? "" : "s"} selected`}
-    </p>
 </div>

--- a/src/lib/components/form-builder/fields/file-input/FileInput.svelte
+++ b/src/lib/components/form-builder/fields/file-input/FileInput.svelte
@@ -120,7 +120,7 @@
     <!-- Drop Area -->
     <div
         class={cn(
-            "border-input bg-background dark:bg-input/30 data-[dragging=true]:bg-accent has-[input:focus]:border-ring has-[input:focus]:ring-ring/50 relative flex min-h-48 flex-col overflow-hidden rounded-xl border border-dashed p-4 transition-colors has-[input:focus]:ring-[3px]",
+            "border-input bg-background dark:bg-input/30 data-[dragging=true]:bg-accent has-[input:focus]:border-ring has-[input:focus]:ring-ring/50 relative flex min-h-48 flex-col overflow-hidden rounded-md border border-dashed p-4 transition-colors has-[input:focus]:ring-[3px]",
             currentFiles.length === 0
                 ? "items-center justify-center text-center"
                 : "gap-3",

--- a/src/lib/components/form-builder/fields/file-input/FileInput.svelte
+++ b/src/lib/components/form-builder/fields/file-input/FileInput.svelte
@@ -215,11 +215,7 @@
                                 !field.preview?.height
                                 ? "max-w-60 mx-auto"
                                 : "",
-                            pending
-                                ? "border-yellow-400 border-dashed"
-                                : marked
-                                  ? "border-red-500 border-dashed"
-                                  : "border-transparent",
+                            // Removed distracting border color changes for pending/marked states
                             field.preview?.class,
                         )}
                         style={field.preview &&
@@ -259,7 +255,7 @@
                         <!-- Overlay states -->
                         {#if pending}
                             <div
-                                class="absolute inset-0 bg-yellow-500/25 backdrop-blur-[1px] flex items-start p-1"
+                                class="absolute inset-0 flex items-start p-1"
                             >
                                 <span
                                     class="text-[10px] font-medium text-yellow-950 dark:text-yellow-100 bg-yellow-400/80 px-1 rounded"
@@ -268,7 +264,7 @@
                             </div>
                         {:else if marked}
                             <div
-                                class="absolute inset-0 bg-red-500/30 backdrop-blur-[1px] flex items-start p-1"
+                                class="absolute inset-0 flex items-start p-1"
                             >
                                 <span
                                     class="text-[10px] font-medium text-red-50 bg-red-600/80 px-1 rounded"

--- a/src/lib/components/form-builder/fields/file-input/FileInput.svelte
+++ b/src/lib/components/form-builder/fields/file-input/FileInput.svelte
@@ -6,20 +6,18 @@
     import { onMount } from "svelte";
     import FileIcon from "../FileIcon.svelte";
     import VideoPreview from "./VideoPreview.svelte";
-    import FileActionBar from "./FileActionBar.svelte";
-    import { TooltipProvider } from "@components/ui/tooltip";
     import { getFileUrl } from "@/services/file.service";
     import { errorToast } from "@/services/toast.service";
 
     export let field: FormField;
-    export let value: any = null;
+    export let value: any = null; // single File / UploadedFile or array
 
     let fileInput: HTMLInputElement;
     let isDragOver = false;
     let isProcessing = false;
 
-    const isImage = (mimeType: string) => mimeType.startsWith("image/");
-    const isVideo = (mimeType: string) => mimeType.startsWith("video/");
+    const isImage = (mimeType: string) => mimeType?.startsWith("image/");
+    const isVideo = (mimeType: string) => mimeType?.startsWith("video/");
     const isFile = (item: any): item is File => item instanceof File;
 
     $: currentFiles = Array.isArray(value) ? value : value ? [value] : [];
@@ -29,41 +27,28 @@
             field.allowedMimeTypes?.length &&
             !field.allowedMimeTypes.includes(file.type)
         ) {
-            return `File type "${file.type}" is not allowed. Allowed types: ${field.allowedMimeTypes.join(", ")}`;
+            return `File type "${file.type}" is not allowed. Allowed: ${field.allowedMimeTypes.join(", ")}`;
         }
-
         if (field.maxFileSize && file.size > field.maxFileSize) {
             const maxSizeMB = (field.maxFileSize / (1024 * 1024)).toFixed(1);
             const fileSizeMB = (file.size / (1024 * 1024)).toFixed(1);
-            return `File size (${fileSizeMB}MB) exceeds maximum allowed size (${maxSizeMB}MB)`;
+            return `File size ${fileSizeMB}MB exceeds ${maxSizeMB}MB`;
         }
-
         return null;
     };
 
     const processFiles = (files: File[]) => {
         if (isProcessing) return;
-
-        const validFiles = files.filter((file) => {
-            const error = validateFile(file);
-            if (error) {
-                errorToast(error);
-                return false;
-            }
-            return true;
+        const valid = files.filter((f) => {
+            const error = validateFile(f);
+            if (error) errorToast(error);
+            return !error;
         });
-
-        if (validFiles.length === 0) return;
-
+        if (!valid.length) return;
         isProcessing = true;
-
-        try {
-            value = field.multiple
-                ? [...currentFiles, ...validFiles]
-                : validFiles[0];
-        } finally {
-            isProcessing = false;
-        }
+        // operations are sync, so we can safely reset after
+        value = field.multiple ? [...currentFiles, ...valid] : valid[0];
+        isProcessing = false;
     };
 
     const handleFileSelect = (event: Event) => {
@@ -74,52 +59,44 @@
     const handleDrop = (event: DragEvent) => {
         event.preventDefault();
         isDragOver = false;
-
         const files = event.dataTransfer?.files;
         if (files?.length) processFiles(Array.from(files));
     };
 
-    const removeFile = (fileToRemove: File | UploadedFileWithDeletionFlag) => {
+    const toggleRemove = (target: File | UploadedFileWithDeletionFlag) => {
         if (isProcessing) return;
-
-        isProcessing = true;
-
-        try {
-            if (isFile(fileToRemove)) {
-                value = field.multiple
-                    ? currentFiles.filter((f) => f !== fileToRemove) || null
-                    : null;
+        if (isFile(target)) {
+            // Newly added local file: remove immediately
+            value = field.multiple
+                ? currentFiles.filter((f) => f !== target)
+                : null;
+        } else {
+            // Existing uploaded file: toggle _markedForDeletion
+            if (field.multiple) {
+                value = currentFiles.map((f) =>
+                    f === target
+                        ? {
+                              ...f,
+                              _markedForDeletion: f._markedForDeletion
+                                  ? undefined
+                                  : true,
+                          }
+                        : f,
+                );
             } else {
-                const isMarkedForDeletion = fileToRemove._markedForDeletion;
-
-                if (field.multiple) {
-                    const updatedFiles = currentFiles.map((f) =>
-                        f === fileToRemove
-                            ? isMarkedForDeletion
-                                ? { ...f, _markedForDeletion: undefined }
-                                : { ...f, _markedForDeletion: true }
-                            : f,
-                    );
-                    value = updatedFiles;
-                } else {
-                    value = isMarkedForDeletion
-                        ? (({ _markedForDeletion, ...rest }) => rest)(
-                              fileToRemove,
-                          )
-                        : { ...fileToRemove, _markedForDeletion: true };
-                }
+                value = target._markedForDeletion
+                    ? (({ _markedForDeletion, ...rest }) => rest)(target)
+                    : { ...target, _markedForDeletion: true };
             }
-        } finally {
-            isProcessing = false;
         }
     };
 
     const formatFileSize = (bytes: number): string => {
-        if (bytes === 0) return "0 Bytes";
+        if (!bytes) return "0B";
         const k = 1024;
-        const sizes = ["Bytes", "KB", "MB", "GB"];
+        const units = ["B", "KB", "MB", "GB"]; // enough
         const i = Math.floor(Math.log(bytes) / Math.log(k));
-        return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
+        return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${units[i]}`;
     };
 
     const getFileData = (file: File | UploadedFileWithDeletionFlag) => ({
@@ -131,162 +108,242 @@
 
     onMount(() => {
         return () => {
-            currentFiles.forEach((file) => {
-                if (isFile(file)) {
-                    URL.revokeObjectURL(getFileData(file).url);
-                }
+            currentFiles.forEach((f) => {
+                if (isFile(f)) URL.revokeObjectURL(getFileData(f).url);
             });
         };
     });
 </script>
 
-<TooltipProvider>
-    <div class="space-y-4">
+<div class="flex flex-col gap-2">
+    <!-- Drop Area -->
+    <div
+        class={cn(
+            "border-input data-[dragging=true]:bg-accent/50 has-[input:focus]:border-ring has-[input:focus]:ring-ring/50 relative flex min-h-48 flex-col overflow-hidden rounded-xl border border-dashed p-4 transition-colors has-[input:focus]:ring-[3px]",
+            currentFiles.length === 0
+                ? "items-center justify-center text-center"
+                : "gap-3",
+            field.disabled || isProcessing
+                ? "opacity-60 pointer-events-none"
+                : "",
+        )}
+        data-dragging={isDragOver || undefined}
+        data-files={currentFiles.length > 0 || undefined}
+        on:dragenter={(e) => {
+            e.preventDefault();
+            isDragOver = true;
+        }}
+        on:dragover={(e) => {
+            e.preventDefault();
+            isDragOver = true;
+        }}
+        on:dragleave={() => (isDragOver = false)}
+        on:drop={handleDrop}
+        role="group"
+    >
         <input
             bind:this={fileInput}
             type="file"
-            class="hidden"
+            class="sr-only"
             multiple={field.multiple}
             accept={field.allowedMimeTypes?.join(",")}
             on:change={handleFileSelect}
             disabled={field.disabled || isProcessing}
             required={field.required}
+            aria-label="Upload files"
         />
 
-        <div
-            class={cn(
-                "border-2 border-dashed bg-background dark:bg-input/30 rounded-lg p-6 text-center transition-colors",
-                isDragOver
-                    ? "border-primary bg-primary/10 dark:bg-primary/20"
-                    : "border-muted-foreground/25",
-                field.disabled || isProcessing
-                    ? "opacity-50 cursor-not-allowed"
-                    : "cursor-pointer hover:border-primary/50",
-            )}
-            on:drop={handleDrop}
-            on:dragover={(e) => {
-                e.preventDefault();
-                isDragOver = true;
-            }}
-            on:dragleave={() => (isDragOver = false)}
-            on:click={() => !isProcessing && fileInput?.click()}
-            role="button"
-            tabindex="0"
-            on:keydown={(e) =>
-                e.key === "Enter" && !isProcessing && fileInput?.click()}
-        >
-            <UploadIcon class="mx-auto h-12 w-12 text-muted-foreground mb-4" />
-            <div class="space-y-2">
-                <p class="text-sm font-medium">
-                    {isProcessing
-                        ? "Processing..."
-                        : field.multiple
-                          ? "Drop files here or click to browse"
-                          : "Drop a file here or click to browse"}
-                </p>
-                {#if field.allowedMimeTypes?.length}
-                    <p class="text-xs text-muted-foreground">
-                        Allowed types: {field.allowedMimeTypes.join(", ")}
-                    </p>
-                {/if}
-                {#if field.maxFileSize}
-                    <p class="text-xs text-muted-foreground">
-                        Maximum file size: {formatFileSize(field.maxFileSize)}
-                    </p>
+        {#if currentFiles.length > 0}
+            <!-- Header + Add more -->
+            <div class="flex items-center justify-between gap-2">
+                <h3 class="truncate text-sm font-medium">
+                    {field.label || "Files"} ({currentFiles.length})
+                </h3>
+                {#if field.multiple}
+                    <button
+                        type="button"
+                        class="inline-flex items-center gap-1 rounded-md border bg-background px-2.5 py-1.5 text-xs font-medium hover:bg-accent transition disabled:opacity-50"
+                        disabled={field.disabled || isProcessing}
+                        on:click={() => fileInput?.click()}
+                    >
+                        <UploadIcon class="-ms-0.5 h-3.5 w-3.5 opacity-60" />
+                        Add more
+                    </button>
                 {/if}
             </div>
-        </div>
-
-        {#if currentFiles.length > 0}
-            <div class="space-y-2">
-                {#each currentFiles as fileData}
-                    {@const { url, name, size, mimeType } =
-                        getFileData(fileData)}
-                    {@const isPending = isFile(fileData)}
-                    {@const isMarkedForDeletion =
-                        !isPending && fileData._markedForDeletion}
-
+            <!-- Grid -->
+            <div
+                class={cn(
+                    "grid gap-3 mt-2",
+                    field.multiple
+                        ? "grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
+                        : "grid-cols-1",
+                )}
+            >
+                {#each currentFiles as f (f.id || f.name || f.fileName)}
+                    {@const data = getFileData(f)}
+                    {@const pending = isFile(f)}
+                    {@const marked = !pending && f._markedForDeletion}
                     <div
-                        class="flex flex-col gap-3 p-4 bg-background dark:bg-input/30 rounded-lg lg:p-6 {isPending
-                            ? 'border border-dashed border-yellow-500'
-                            : isMarkedForDeletion
-                              ? 'border border-dashed border-red-500'
-                              : ''}"
+                        class={cn(
+                            "relative rounded-md overflow-hidden group bg-accent/40 border flex items-center justify-center",
+                            // aspect / size logic
+                            field.preview?.aspect === "video"
+                                ? "aspect-video"
+                                : field.preview?.aspect === "wide"
+                                  ? "aspect-[16/9]"
+                                  : field.preview?.aspect === "portrait"
+                                    ? "aspect-[3/4]"
+                                    : field.preview?.aspect === "square" ||
+                                        !field.preview?.aspect
+                                      ? "aspect-square"
+                                      : field.preview?.aspect, // raw tailwind aspect if custom
+                            field.preview?.width
+                                ? `w-[${field.preview.width}px]`
+                                : "",
+                            field.preview?.height
+                                ? `h-[${field.preview.height}px]`
+                                : "",
+                            !field.multiple &&
+                                currentFiles.length === 1 &&
+                                !field.preview?.width &&
+                                !field.preview?.height
+                                ? "max-w-60 mx-auto"
+                                : "",
+                            pending
+                                ? "border-yellow-400 border-dashed"
+                                : marked
+                                  ? "border-red-500 border-dashed"
+                                  : "border-transparent",
+                            field.preview?.class,
+                        )}
                     >
-                        {#if isPending}
+                        {#if isImage(data.mimeType)}
+                            <img
+                                src={data.url}
+                                alt={data.name}
+                                class="size-full object-cover"
+                                draggable={false}
+                            />
+                        {:else if isVideo(data.mimeType)}
+                            <VideoPreview
+                                src={data.url}
+                                title={data.name}
+                                thumbnailClass="size-full object-cover"
+                            />
+                        {:else}
                             <div
-                                class="flex items-center gap-2 text-xs text-yellow-600 dark:text-yellow-400"
+                                class="flex flex-col items-center justify-center size-full gap-2 text-xs text-muted-foreground"
                             >
-                                <div
-                                    class="w-2 h-2 bg-yellow-500 rounded-full"
-                                ></div>
-                                Pending upload
-                            </div>
-                        {:else if isMarkedForDeletion}
-                            <div
-                                class="flex items-center gap-2 text-xs text-red-600 dark:text-red-400"
-                            >
-                                <div
-                                    class="w-2 h-2 bg-red-500 rounded-full"
-                                ></div>
-                                Marked for deletion
+                                <FileIcon
+                                    mimeType={data.mimeType}
+                                    fileName={data.name}
+                                    size={36}
+                                />
+                                <span class="px-1 truncate max-w-[90%]"
+                                    >{data.name}</span
+                                >
                             </div>
                         {/if}
 
-                        <div class="flex-shrink-0 w-full sm:w-auto">
-                            {#if isImage(mimeType)}
-                                <img
-                                    src={url}
-                                    loading="lazy"
-                                    draggable={false}
-                                    alt={name}
-                                    class="w-full h-48 object-cover rounded-lg select-none sm:w-20 sm:h-20 md:w-24 md:h-24 lg:w-28 lg:h-28"
-                                />
-                            {:else if isVideo(mimeType)}
-                                <VideoPreview
-                                    src={url}
-                                    title={name}
-                                    thumbnailClass="w-full object-cover rounded-lg select-none"
-                                />
-                            {:else}
-                                <div
-                                    class="flex justify-center sm:justify-start"
+                        <!-- Overlay states -->
+                        {#if pending}
+                            <div
+                                class="absolute inset-0 bg-yellow-500/25 backdrop-blur-[1px] flex items-start p-1"
+                            >
+                                <span
+                                    class="text-[10px] font-medium text-yellow-950 dark:text-yellow-100 bg-yellow-400/80 px-1 rounded"
+                                    >Pending</span
                                 >
-                                    <FileIcon
-                                        {mimeType}
-                                        fileName={name}
-                                        size={32}
-                                        class="text-muted-foreground"
-                                    />
-                                </div>
+                            </div>
+                        {:else if marked}
+                            <div
+                                class="absolute inset-0 bg-red-500/30 backdrop-blur-[1px] flex items-start p-1"
+                            >
+                                <span
+                                    class="text-[10px] font-medium text-red-50 bg-red-600/80 px-1 rounded"
+                                    >Marked</span
+                                >
+                            </div>
+                        {/if}
+
+                        <!-- Remove / Toggle button -->
+                        <button
+                            type="button"
+                            class="absolute -top-2 -right-2 h-6 w-6 rounded-full border-2 border-background bg-background/90 shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring flex items-center justify-center text-[10px] font-semibold hover:scale-105 transition"
+                            on:click={() => toggleRemove(f)}
+                            aria-label={pending
+                                ? "Remove file"
+                                : marked
+                                  ? "Undo deletion"
+                                  : "Mark for deletion"}
+                        >
+                            {#if pending}
+                                ✕
+                            {:else if marked}
+                                ↺
+                            {:else}
+                                ✕
                             {/if}
-                        </div>
+                        </button>
 
-                        <div class="min-w-0 flex-1 space-y-1">
-                            <p class="text-sm font-medium truncate">{name}</p>
-                            <p class="text-xs text-muted-foreground">
-                                {formatFileSize(size)}
-                            </p>
+                        <!-- Meta footer -->
+                        <div
+                            class="absolute left-0 right-0 bottom-0 bg-gradient-to-t from-black/60 to-black/0 text-[10px] text-white px-1.5 py-1 flex items-center justify-between gap-1"
+                        >
+                            <span class="truncate" title={data.name}
+                                >{data.name}</span
+                            >
+                            <span>{formatFileSize(data.size)}</span>
                         </div>
-
-                        <FileActionBar
-                            fileData={isPending
-                                ? {
-                                      id: "",
-                                      originalName: name,
-                                      fileName: name,
-                                      mimeType,
-                                      size,
-                                      path: url,
-                                      uploadedAt: new Date(),
-                                  }
-                                : fileData}
-                            disabled={field.disabled || isProcessing}
-                            onDelete={() => removeFile(fileData)}
-                        />
                     </div>
                 {/each}
             </div>
+        {:else}
+            <div
+                class="flex flex-col items-center justify-center px-4 py-3 text-center select-none"
+            >
+                <div
+                    class="mb-2 flex h-11 w-11 items-center justify-center rounded-full border bg-background"
+                    aria-hidden="true"
+                >
+                    <UploadIcon class="h-4 w-4 opacity-60" />
+                </div>
+                <p class="mb-1.5 text-sm font-medium">
+                    {field.multiple
+                        ? "Drop your files here"
+                        : "Drop your file here"}
+                </p>
+                <p class="text-muted-foreground text-xs">
+                    {#if field.allowedMimeTypes?.length}
+                        {field.allowedMimeTypes.join(", ")}
+                    {/if}
+                    {#if field.maxFileSize}
+                        {#if field.allowedMimeTypes?.length}&nbsp;•&nbsp;{/if}
+                        Max {formatFileSize(field.maxFileSize)}
+                    {/if}
+                </p>
+                <button
+                    type="button"
+                    class="mt-4 inline-flex items-center gap-2 rounded-md border bg-background px-3 py-2 text-sm font-medium hover:bg-accent transition disabled:opacity-50"
+                    disabled={field.disabled || isProcessing}
+                    on:click={() => fileInput?.click()}
+                >
+                    <UploadIcon class="-ms-1 h-4 w-4 opacity-60" />
+                    Select {field.multiple ? "files" : "file"}
+                </button>
+            </div>
         {/if}
     </div>
-</TooltipProvider>
+
+    <!-- Accessibility region -->
+    <p
+        aria-live="polite"
+        role="status"
+        class="text-muted-foreground text-center text-xs mt-1"
+    >
+        {currentFiles.length === 0
+            ? "No files selected"
+            : `${currentFiles.length} file${currentFiles.length === 1 ? "" : "s"} selected`}
+    </p>
+</div>

--- a/src/lib/components/form-builder/fields/file-input/FileInput.svelte
+++ b/src/lib/components/form-builder/fields/file-input/FileInput.svelte
@@ -187,7 +187,7 @@
                     {@const marked = !pending && f._markedForDeletion}
                     <div
                         class={cn(
-                            "relative rounded-md overflow-hidden group bg-accent/40 border flex items-center justify-center",
+                            "relative rounded-md group bg-accent/40 border border-transparent flex items-center justify-center overflow-visible",
                             (field.preview?.aspect === "video" &&
                                 "aspect-video") ||
                                 (field.preview?.aspect === "wide" &&
@@ -220,7 +220,8 @@
                             <img
                                 src={data.url}
                                 alt={data.name}
-                                class="size-full object-cover"
+                                class="size-full object-cover select-none"
+                                loading="lazy"
                                 draggable={false}
                             />
                         {:else if isVideo(data.mimeType)}
@@ -268,7 +269,7 @@
                         <!-- Remove / Toggle button -->
                         <button
                             type="button"
-                            class="absolute -top-2 -right-2 h-6 w-6 rounded-full border-2 border-background bg-background/90 shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring flex items-center justify-center text-[10px] font-semibold hover:scale-105 transition"
+                            class="absolute -top-2 -right-2 size-6 cursor-pointer rounded-full border-2 border-background bg-destructive shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring flex items-center justify-center text-[10px] font-semibold hover:scale-105 transition text-white"
                             on:click={() => toggleRemove(f)}
                             aria-label={pending
                                 ? "Remove file"

--- a/src/lib/components/form-builder/fields/file-input/FileInput.svelte
+++ b/src/lib/components/form-builder/fields/file-input/FileInput.svelte
@@ -187,23 +187,16 @@
                     <div
                         class={cn(
                             "relative rounded-md overflow-hidden group bg-accent/40 border flex items-center justify-center",
-                            // aspect / size logic
-                            field.preview?.aspect === "video"
-                                ? "aspect-video"
-                                : field.preview?.aspect === "wide"
-                                  ? "aspect-[16/9]"
-                                  : field.preview?.aspect === "portrait"
-                                    ? "aspect-[3/4]"
-                                    : field.preview?.aspect === "square" ||
-                                        !field.preview?.aspect
-                                      ? "aspect-square"
-                                      : field.preview?.aspect, // raw tailwind aspect if custom
-                            field.preview?.width
-                                ? `w-[${field.preview.width}px]`
-                                : "",
-                            field.preview?.height
-                                ? `h-[${field.preview.height}px]`
-                                : "",
+                            (field.preview?.aspect === "video" &&
+                                "aspect-video") ||
+                                (field.preview?.aspect === "wide" &&
+                                    "aspect-[16/9]") ||
+                                (field.preview?.aspect === "portrait" &&
+                                    "aspect-[3/4]") ||
+                                (field.preview?.aspect === "square" &&
+                                    "aspect-square") ||
+                                (!field.preview?.aspect && "aspect-square") ||
+                                field.preview?.aspect,
                             !field.multiple &&
                                 currentFiles.length === 1 &&
                                 !field.preview?.width &&
@@ -217,6 +210,10 @@
                                   : "border-transparent",
                             field.preview?.class,
                         )}
+                        style={field.preview &&
+                        (field.preview.width || field.preview.height)
+                            ? `${field.preview.width ? `width:${field.preview.width}px;` : ""}${field.preview.height ? `height:${field.preview.height}px;` : ""}`
+                            : undefined}
                     >
                         {#if isImage(data.mimeType)}
                             <img

--- a/src/lib/components/form-builder/types.ts
+++ b/src/lib/components/form-builder/types.ts
@@ -266,6 +266,13 @@ export interface FormField {
     // File upload specific options
     allowedMimeTypes?: string[]; // For file fields - allowed MIME types (default: all)
     maxFileSize?: number; // For file fields - maximum file size in bytes
+    // File preview options
+    preview?: {
+        width?: number; // target width in px (wrapper)
+        height?: number; // target height in px (wrapper)
+        class?: string; // additional utility classes to apply to preview wrapper
+        aspect?: 'square' | 'video' | 'wide' | 'portrait' | string; // templated aspect (falls back to raw string)
+    };
     // Tags input specific options
     maxTags?: number; // For tags fields - maximum number of tags allowed
     validateTag?: (tag: string, existingTags: string[]) => string | undefined; // For tags fields - custom tag validation function
@@ -331,6 +338,7 @@ export interface FieldBuilder {
     autoResize(isAutoResize?: boolean): FieldBuilder;
     allowedMimeTypes(types: string[]): FieldBuilder;
     maxFileSize(size: number): FieldBuilder;
+    preview(options: { width?: number; height?: number; class?: string; aspect?: 'square' | 'video' | 'wide' | 'portrait' | string }): FieldBuilder;
     maxTags(count: number): FieldBuilder;
     validateTag(validator: (tag: string, existingTags: string[]) => string | undefined): FieldBuilder;
     allowDuplicates(allow?: boolean): FieldBuilder;

--- a/src/lib/components/form-builder/types.ts
+++ b/src/lib/components/form-builder/types.ts
@@ -338,7 +338,10 @@ export interface FieldBuilder {
     autoResize(isAutoResize?: boolean): FieldBuilder;
     allowedMimeTypes(types: string[]): FieldBuilder;
     maxFileSize(size: number): FieldBuilder;
-    preview(options: { width?: number; height?: number; class?: string; aspect?: 'square' | 'video' | 'wide' | 'portrait' | string }): FieldBuilder;
+    previewWidth(width: number): FieldBuilder;
+    previewHeight(height: number): FieldBuilder;
+    previewClass(className: string): FieldBuilder;
+    previewAspect(aspect: 'square' | 'video' | 'wide' | 'portrait' | string): FieldBuilder;
     maxTags(count: number): FieldBuilder;
     validateTag(validator: (tag: string, existingTags: string[]) => string | undefined): FieldBuilder;
     allowDuplicates(allow?: boolean): FieldBuilder;

--- a/src/lib/components/form-builder/types.ts
+++ b/src/lib/components/form-builder/types.ts
@@ -300,6 +300,8 @@ export interface FormField {
     allowVariables?: boolean; // Whether this field supports global variables (default: true for text-based fields)
     // Visibility properties
     hidden?: boolean; // Whether this field should be hidden from rendering
+    // File (multiple) specific behavior
+    allowReorder?: boolean; // Whether multiple file items can be reordered via drag & drop
 }
 
 // Type for FieldBuilder instances (for better type checking)
@@ -352,6 +354,8 @@ export interface FieldBuilder {
     default(value: any): FieldBuilder;
     allowVariables(allow?: boolean): FieldBuilder;
     hidden(isHidden?: boolean): FieldBuilder;
+    // File (multiple) specific behavior
+    allowReorder?(allow?: boolean): FieldBuilder;
 }
 
 // Schema item can be either a field, field builder, tabs container, tabs builder, or grid layout


### PR DESCRIPTION
This pull request introduces enhancements to the file input fields in the form builder and carousel components, focusing on improved file preview customization and support for multiple file uploads with drag-and-drop reordering. The changes are grouped into two main themes: file preview and multiple file handling, and internal logic improvements for file reference management.

**File preview and multiple file handling enhancements:**

* Added support for customizing file preview dimensions, aspect ratio, and CSS classes in the `FormField` interface and `FieldBuilder` class, enabling more flexible UI presentation for uploaded files. [[1]](diffhunk://#diff-2cf149c16f49010c37fd9ee52306fdac8a125c110363790c943d2c33135d9751R269-R275) [[2]](diffhunk://#diff-bb43fbeab48f4fe840e69013648b5f5f44c4dfc268fae53f3848964f8cbeb67cR243-R264) [[3]](diffhunk://#diff-2cf149c16f49010c37fd9ee52306fdac8a125c110363790c943d2c33135d9751R343-R346)
* Introduced the `allowReorder` option for file input fields, allowing users to reorder multiple uploaded files via drag-and-drop in both schema definitions and builder interfaces. [[1]](diffhunk://#diff-2cf149c16f49010c37fd9ee52306fdac8a125c110363790c943d2c33135d9751R303-R304) [[2]](diffhunk://#diff-2cf149c16f49010c37fd9ee52306fdac8a125c110363790c943d2c33135d9751R357-R358) [[3]](diffhunk://#diff-bb43fbeab48f4fe840e69013648b5f5f44c4dfc268fae53f3848964f8cbeb67cR243-R264) [[4]](diffhunk://#diff-dc30c5fcf494b5db78d9e9193cb3ea7698c263c1671591c7d69bbdcabfc77ca1R28-R30)
* Enabled the `multiple` option for the carousel slide image input, allowing multiple images to be uploaded and reordered.

**Internal logic improvements:**

* Updated the `replaceFileReferences` function to cleanly handle deletion flags for uploaded files, ensuring that files marked for deletion are removed from both single and multiple file fields during data processing.